### PR TITLE
Fix "invalid prop type children" errors.

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -11,7 +11,7 @@ function sleep(ms = 0) {
 
 async function load() {
   await sleep(200);
-  return <p>Hello Async Route!</p>
+  return () => <p>Hello Async Route!</p>;
 }
 
 it('loads components asynchronously', async () => {

--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ export default class MatchAsync extends Component {
   }
 
   getComponent = () => {
-    const { getComponent, ...matchProps } = this.props;
-    const maybePromise = getComponent(matchProps, (err, component) => {
+    const { getComponent } = this.props;
+    const maybePromise = getComponent((err, component) => {
       if (err) {
-        this.errorHandler();
+        this.errorHandler(err);
       } else {
         this.setComponent(component);
       }
@@ -30,7 +30,7 @@ export default class MatchAsync extends Component {
   errorHandler = (err) => {
     const { onError } = this.props;
     if (onError) {
-      onError();
+      onError(err);
     } else {
       throw err;
     }
@@ -46,7 +46,7 @@ export default class MatchAsync extends Component {
       <Match
         {...this.props}
         render={() => (
-        component !== undefined ? component : null
+        component !== undefined ? React.createElement(component) : null
       )}
       />
     );

--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ export default class MatchAsync extends Component {
     return (
       <Match
         {...this.props}
-        render={() => (
-        component !== undefined ? React.createElement(component) : null
+        render={(matchProps) => (
+        component !== undefined ? React.createElement(component, matchProps) : null
       )}
       />
     );


### PR DESCRIPTION
Thanks for such a clever little module, it's a real lifesaver! I was seeing errors thrown by `MatchProvider` indicating that it was being passed something other than a React node for `children`. Sure enough, it was just getting the classes' constructor functions. Wrapping the component in a call to `React.createElement` resolves the issue.
